### PR TITLE
Fix max length bug and add integration test cases for max length.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ fn main() {
     let length: i32 = get_cli_param_or_default(&cli_args, "length").unwrap();
     let password_length = match length {
         l if l < 0 => DEFAULT_LENGTH,
-        l if l > max_length && max_length > 16 => DEFAULT_MAX_LENGTH,
+        l if l > max_length => DEFAULT_MAX_LENGTH,
         _ => length,
     };
     let password = gen_pwd(password_length as usize);

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -17,4 +17,22 @@ mod cli_test {
             .satisfies(|p| p.chars().count() == 24, "Custom invocation successful")
             .unwrap();
     }
+
+    #[test]
+    fn max_length_override_test() {
+        assert_cli::Assert::main_binary()
+            .with_args(&["-l", "420", "-m", "1024"])
+            .stdout()
+            .satisfies(|p| p.chars().count() == 420, "Max length overriden")
+            .unwrap();
+    }
+
+    #[test]
+    fn invocation_defaults_to_max_length() {
+        assert_cli::Assert::main_binary()
+            .with_args(&["-l", "420"])
+            .stdout()
+            .satisfies(|p| p.chars().count() == 128, "Default max length")
+            .unwrap();
+    }
 }


### PR DESCRIPTION
Previously there was a logic error which didn't limit the length of the generated password even when the max length override option was absent.
This fixes it and also adds integration test cases for it so that a regression can be caught during development time.